### PR TITLE
Update path for OG images

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -54,7 +54,7 @@ module.exports = {
     title: "Netlify Store - Awesome Apparel, Stickers, and Other Swag",
     description:
       "Netlify socks, stickers, shirts, mugs, and much more! Check out the store for official Netliswag and Jamstack gear. PS - plz share with other devs.",
-    ogimage: "https://swag.netlify.com/ogimage.png",
+    ogimage: "/ogimage.png",
     siteUrl: "https://swag.netlify.com",
   },
 };

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -7,11 +7,9 @@ import styles from '../styles/layout.module.css';
 
 import '../styles/global.css';
 import { Footer } from './footer';
-import SEO from './seo.js';
 
 const Layout = ({ children, home = false }) => (
   <Fragment>
-    <SEO />
     {/* <AnnouncementBar /> */}
     <Header />
     <div className={styles.container}>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -29,16 +29,16 @@ const SEO = ({ metadata }) => {
       <meta name="description" content={description} />
       <meta itemprop="name" content={title} />
       <meta itemprop="description" content={description} />
-      <meta itemprop="image" content={ogimage} />
+      <meta itemprop="image" content={`https://swag.netlify.com${ogimage}`} />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:site" content="@netlify" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />
       <meta name="twitter:creator" content="@netlify" />
-      <meta name="twitter:image" content={ogimage} />
-      <meta name="og:image" content={ogimage} />
-      <meta name="og:image:secure_url" content={ogimage} />
-      <meta name="image" property="og:image" content={ogimage} />
+      <meta name="twitter:image" content={`https://swag.netlify.com${ogimage}`} />
+      <meta name="og:image" content={`https://swag.netlify.com${ogimage}`} />
+      <meta name="og:image:secure_url" content={`https://swag.netlify.com${ogimage}`} />
+      <meta name="image" property="og:image" content={`https://swag.netlify.com${ogimage}`} />
       <meta property="og:site_name" content="Netlify Store" />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -20,6 +20,7 @@ const SEO = ({ metadata }) => {
   const title = metadata?.title ? `${metadata.title} - Netlify Store` : defaults.title;
   const description = metadata?.description ? `${metadata.description} Check this product and more at the Netlify Store` : defaults.description;
   const ogimage = metadata?.images ? metadata.images[0].localFile.childImageSharp.fluid.src : defaults.ogimage;
+  const summary = metadata?.summary ? metadata.summary : "summary_large_image"
 
   return (
     <Helmet>
@@ -30,7 +31,7 @@ const SEO = ({ metadata }) => {
       <meta itemprop="name" content={title} />
       <meta itemprop="description" content={description} />
       <meta itemprop="image" content={`https://swag.netlify.com${ogimage}`} />
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content={summary} />
       <meta name="twitter:site" content="@netlify" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,6 +4,7 @@ import Layout from '../components/layout';
 import { CollectionListings } from '../components/collection-listings';
 import { HomeIntro } from '../components/home-intro';
 import { PromotionalBanner } from '../components/promotional-banner';
+import SEO from "../components/seo";
 
 export const query = graphql`
   {
@@ -71,6 +72,7 @@ export default ({ data }) => {
   const { title, body } = data.shopifyPage;
   return (
     <Layout home>
+      <SEO />
       <PromotionalBanner />
       <HomeIntro title={title} body={body} />
       <div id="promo">

--- a/src/templates/product-page.js
+++ b/src/templates/product-page.js
@@ -74,7 +74,7 @@ const ProductPage = ({ data }) => {
 
   return (
     <Layout>
-      <SEO metadata={{...product }}/>
+      <SEO metadata={{"summary": "summary", ...product }}/>
       <div className={`${styles.details} ${styles.detailsProduct}`}>
         <div className={styles.productDetailsContentContainer}>
           <h1 className={styles.heading}>{product.title}</h1>


### PR DESCRIPTION
Add absolute paths to make sure OG images work on Twitter.

Also fix the twitter card preview to show full size image for the homepage and small size for the products page.

### Screenshots

<img width="1560" alt="Screen Shot 2020-08-03 at 2 26 57 PM" src="https://user-images.githubusercontent.com/6691035/89214772-6afc8980-d595-11ea-9ba8-c9a754d7c8a3.png">


