### PR TITLE
fix: ui issue on tagline

### DIFF
--- a/src/styles/contributors.module.css
+++ b/src/styles/contributors.module.css
@@ -73,4 +73,6 @@
   text-align: center;
   text-shadow: 0 1px 0 var(--color-black);
   width: 100%;
+  margin: 0;
+  padding: 0 5vw;
 }


### PR DESCRIPTION
While ordering myself some swag yesterday I found a really small UI issue on the contributors tagline - using my Android device the tagline had no horizontal padding so it was sitting flush against the edge of the screen and looked a little weird.

Before:
<img width="407" alt="Screenshot 2020-08-05 at 21 33 59" src="https://user-images.githubusercontent.com/6544116/89456011-7d2c2280-d763-11ea-961a-06d7d3cfe633.png">

With fix:
<img width="407" alt="Screenshot 2020-08-05 at 21 34 40" src="https://user-images.githubusercontent.com/6544116/89456032-87e6b780-d763-11ea-9740-35f77a16be0e.png">

