### PR TITLE
feat: add shared access state to protect product pages

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { CartProvider } from './src/context/cart-context';
+import { AccessProvider } from './src/context/access-context';
 
 export const wrapRootElement = ({ element }) => (
-  <CartProvider>{element}</CartProvider>
+  <AccessProvider>
+    <CartProvider>{element}</CartProvider>
+  </AccessProvider>
 );

--- a/src/components/password-lock.js
+++ b/src/components/password-lock.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styles from '../styles/password-lock.module.css';
 
 export function PasswordLock({ handleCorrectPassword }) {
-  const [password, setPassword] = useState();
+  const [password, setPassword] = useState('');
 
   return (
     <form

--- a/src/context/access-context.js
+++ b/src/context/access-context.js
@@ -1,0 +1,62 @@
+import React, { createContext, useEffect, useState, useContext } from 'react';
+
+const AccessContext = createContext();
+
+export const AccessProvider = ({ children }) => {
+  const [access, setAccess] = useState();
+
+  return (
+    <AccessContext.Provider value={{ access, setAccess }}>
+      {children}
+    </AccessContext.Provider>
+  );
+};
+
+export const useAccess = () => {
+  const { access, setAccess } = useContext(AccessContext);
+
+  const initializeSetting = ({
+    localStorageKey,
+    setValue,
+    value,
+    fallbackValue,
+  }) => {
+    if (typeof value !== 'undefined') return;
+
+    const storedValue = localStorage.getItem(localStorageKey);
+    if (storedValue !== null) {
+      /*
+       * For boolean values, we need to run JSON.parse() or else they’ll be
+       * treated like strings. However, if we try to JSON.parse() a plain ol’
+       * string, it borks. So this tries to parse first, then falls back to
+       * using the string value if that doesn’t work.
+       */
+      let parsedValue;
+      try {
+        parsedValue = JSON.parse(storedValue);
+      } catch (_) {
+        parsedValue = storedValue;
+      }
+
+      setValue(parsedValue);
+    } else {
+      setValue(fallbackValue);
+    }
+  };
+
+  useEffect(() => {
+    initializeSetting({
+      localStorageKey: 'swag.netlify.com:netlify-exclusive',
+      setValue: setAccess,
+      value: access,
+      fallbackValue: false,
+    });
+  }, [access, setAccess]);
+
+  const updateAccess = (newAccess) => {
+    localStorage.setItem('swag.netlify.com:netlify-exclusive', newAccess);
+    setAccess(newAccess);
+  };
+
+  return { access, updateAccess };
+};

--- a/src/pages/keyboard.js
+++ b/src/pages/keyboard.js
@@ -52,7 +52,7 @@ export const query = graphql`
 `;
 
 export default ({ data }) => {
-  const [secret, setSecret] = useState();
+  const [isAllowed, setIsAllowed] = useState();
 
   const { title, body } = data.shopifyPage;
   return (
@@ -63,13 +63,13 @@ export default ({ data }) => {
           description: 'Swag that’s only available to Netlify team members.',
         }}
       />
-      {secret ? (
+      {isAllowed ? (
         <>
           <HomeIntro title={title} body={body} />
           <CollectionListings collection={data.shopifyCollection} />
         </>
       ) : (
-        <PasswordLock handleCorrectPassword={() => setSecret(true)} />
+        <PasswordLock handleCorrectPassword={() => setIsAllowed(true)} />
       )}
     </Layout>
   );

--- a/src/pages/keyboard.js
+++ b/src/pages/keyboard.js
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 import { HomeIntro } from '../components/home-intro';
 import { CollectionListings } from '../components/collection-listings';
 import { PasswordLock } from '../components/password-lock';
 import SEO from '../components/seo';
+import { useAccess } from '../context/access-context';
 
 export const query = graphql`
   {
@@ -52,9 +53,9 @@ export const query = graphql`
 `;
 
 export default ({ data }) => {
-  const [isAllowed, setIsAllowed] = useState();
-
+  const { access, updateAccess } = useAccess();
   const { title, body } = data.shopifyPage;
+
   return (
     <Layout home>
       <SEO
@@ -63,13 +64,13 @@ export default ({ data }) => {
           description: 'Swag that’s only available to Netlify team members.',
         }}
       />
-      {isAllowed ? (
+      {access ? (
         <>
           <HomeIntro title={title} body={body} />
           <CollectionListings collection={data.shopifyCollection} />
         </>
       ) : (
-        <PasswordLock handleCorrectPassword={() => setIsAllowed(true)} />
+        <PasswordLock handleCorrectPassword={() => updateAccess(true)} />
       )}
     </Layout>
   );


### PR DESCRIPTION
this adds shared state for the access control that’s also persisted in localStorage so you only have to enter the collection password once. I’m not stressing about keeping these collections and products super secure since this isn’t sensitive data and the worst thing that happens is someone gives us money that they weren’t supposed to